### PR TITLE
Fix crashing in android 15 (#44)

### DIFF
--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/service/PlayerService.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/service/PlayerService.kt
@@ -489,7 +489,9 @@ class PlayerService : InvincibleService(), Player.Listener, PlaybackStatsListene
 
     private fun maybeShowSongCoverInLockScreen() {
         val bitmap =
-            if (isAtLeastAndroid13 || isShowingThumbnailInLockscreen) bitmapProvider.bitmap else null
+            if ((isAtLeastAndroid13 || isShowingThumbnailInLockscreen) && bitmapProvider.bitmap.isRecycled) {
+                bitmapProvider.bitmap
+            } else null
 
         metadataBuilder.putBitmap(MediaMetadata.METADATA_KEY_ART, bitmap)
 


### PR DESCRIPTION
- Check if bitmap is recycled before accessing it